### PR TITLE
Replacing inferior threat sounds with more fear

### DIFF
--- a/🐶.js
+++ b/🐶.js
@@ -18,7 +18,7 @@ client.addListener('message', function (from, to, message) {
     console.log(from + ' => ' + to + ': ' + message);
     const match = message.match(/do+g/gi);
     match && client.say(to, match.map(() => '🐶').join(' '));
-    message.includes('🐈') && client.action(to, '🐕 woof woof!');
+    message.includes('🐈') && client.action(to, '🐕 bork bork!');
 });
 
 client.addListener('error', function(message) {


### PR DESCRIPTION
Scientific studies have shown that the words "woof woof" are kind and gentle, where as "bork bork" offers a lot more dominance and scares things especially cats away.